### PR TITLE
fix: use Open WebUI config flags for Qdrant/Milvus multitenancy detection

### DIFF
--- a/prune_cli_interactive.py
+++ b/prune_cli_interactive.py
@@ -55,7 +55,8 @@ try:
     # Import Open WebUI modules using compatibility layer (handles pip/docker/git installs)
     from prune_imports import (
         Users, Chats, Files, Notes, Prompts, Models, Knowledges, Functions,
-        Tools, Skills, Folders, get_db, CACHE_DIR, VECTOR_DB_CLIENT, VECTOR_DB
+        Tools, Skills, Folders, get_db, CACHE_DIR, VECTOR_DB_CLIENT, VECTOR_DB,
+        ENABLE_QDRANT_MULTITENANCY_MODE, ENABLE_MILVUS_MULTITENANCY_MODE
     )
     import time
     import sqlite3
@@ -139,7 +140,9 @@ class InteractivePruneUI:
 
             # Initialize vector cleaner
             self.vector_cleaner = get_vector_database_cleaner(
-                VECTOR_DB, VECTOR_DB_CLIENT, Path(CACHE_DIR)
+                VECTOR_DB, VECTOR_DB_CLIENT, Path(CACHE_DIR),
+                enable_milvus_multitenancy=ENABLE_MILVUS_MULTITENANCY_MODE,
+                enable_qdrant_multitenancy=ENABLE_QDRANT_MULTITENANCY_MODE,
             )
             console.print(f"[green]✓[/green] Vector database: {VECTOR_DB}")
 

--- a/prune_core.py
+++ b/prune_core.py
@@ -1781,13 +1781,22 @@ class NoOpVectorDatabaseCleaner(VectorDatabaseCleaner):
         return True
 
 
-def get_vector_database_cleaner(vector_db_type: str, vector_db_client, cache_dir: Path) -> VectorDatabaseCleaner:
+def get_vector_database_cleaner(
+    vector_db_type: str,
+    vector_db_client,
+    cache_dir: Path,
+    enable_milvus_multitenancy: bool = False,
+    enable_qdrant_multitenancy: bool = False,
+) -> VectorDatabaseCleaner:
     """
     Factory function to get the appropriate vector database cleaner.
 
     This function detects the configured vector database type and returns
     the appropriate cleaner implementation. Community contributors can
     extend this function to support additional vector databases.
+
+    Multitenancy detection uses the Open WebUI config flags
+    (ENABLE_MILVUS_MULTITENANCY_MODE, ENABLE_QDRANT_MULTITENANCY_MODE).
 
     Supported databases:
     - ChromaDB: SQLite-based vector database with directory storage
@@ -1809,16 +1818,14 @@ def get_vector_database_cleaner(vector_db_type: str, vector_db_client, cache_dir
         log.debug("Using PGVector cleaner")
         return PGVectorDatabaseCleaner(vector_db_client)
     elif "milvus" in vector_db_type:
-        # Detect multitenancy mode by checking for shared_collections attribute
-        if hasattr(vector_db_client, 'shared_collections'):
+        if enable_milvus_multitenancy:
             log.debug("Using Milvus Multitenancy cleaner")
             return MilvusMultitenancyDatabaseCleaner(vector_db_client)
         else:
             log.debug("Using Milvus standard cleaner")
             return MilvusDatabaseCleaner(vector_db_client)
     elif "qdrant" in vector_db_type:
-        # Detect multitenancy mode by checking for shared_collections attribute
-        if hasattr(vector_db_client, 'shared_collections'):
+        if enable_qdrant_multitenancy:
             log.debug("Using Qdrant Multitenancy cleaner")
             return QdrantMultitenancyDatabaseCleaner(vector_db_client)
         else:
@@ -1829,3 +1836,5 @@ def get_vector_database_cleaner(vector_db_type: str, vector_db_client, cache_dir
             f"No specific cleaner for vector database type: {vector_db_type}, using no-op cleaner"
         )
         return NoOpVectorDatabaseCleaner()
+
+

--- a/prune_imports.py
+++ b/prune_imports.py
@@ -126,6 +126,11 @@ if _import_strategy == "pip" or _import_strategy == "backend_path":
         VECTOR_DB_CLIENT = None
         VECTOR_DB = None
 
+    from open_webui.config import (
+        ENABLE_QDRANT_MULTITENANCY_MODE,
+        ENABLE_MILVUS_MULTITENANCY_MODE,
+    )
+
 elif _import_strategy == "git":
     # Import from backend.open_webui.* (git installation)
     from backend.open_webui.models.users import Users
@@ -150,6 +155,11 @@ elif _import_strategy == "git":
     except ImportError:
         VECTOR_DB_CLIENT = None
         VECTOR_DB = None
+
+    from backend.open_webui.config import (
+        ENABLE_QDRANT_MULTITENANCY_MODE,
+        ENABLE_MILVUS_MULTITENANCY_MODE,
+    )
 
 
 # Export all for easy importing
@@ -185,6 +195,8 @@ __all__ = [
     'CACHE_DIR',
     'VECTOR_DB_CLIENT',
     'VECTOR_DB',
+    'ENABLE_QDRANT_MULTITENANCY_MODE',
+    'ENABLE_MILVUS_MULTITENANCY_MODE',
     '_import_strategy',
 ]
 

--- a/standalone_prune.py
+++ b/standalone_prune.py
@@ -53,7 +53,8 @@ try:
     )
     from prune_imports import (
         Users, Chats, Files, Notes, Prompts, Models, Knowledges, Functions,
-        Tools, Skills, Folders, get_db, VECTOR_DB, VECTOR_DB_CLIENT, CACHE_DIR
+        Tools, Skills, Folders, get_db, VECTOR_DB, VECTOR_DB_CLIENT, CACHE_DIR,
+        ENABLE_QDRANT_MULTITENANCY_MODE, ENABLE_MILVUS_MULTITENANCY_MODE
     )
     from sqlalchemy import text
     import time
@@ -434,7 +435,11 @@ def run_prune(form_data: PruneDataForm):
 
     try:
         # Get vector database cleaner based on configuration
-        vector_cleaner = get_vector_database_cleaner(VECTOR_DB, VECTOR_DB_CLIENT, Path(CACHE_DIR))
+        vector_cleaner = get_vector_database_cleaner(
+            VECTOR_DB, VECTOR_DB_CLIENT, Path(CACHE_DIR),
+            enable_milvus_multitenancy=ENABLE_MILVUS_MULTITENANCY_MODE,
+            enable_qdrant_multitenancy=ENABLE_QDRANT_MULTITENANCY_MODE,
+        )
 
         if form_data.dry_run:
             log.info("Starting data pruning preview (dry run)")


### PR DESCRIPTION
Instead of sniffing client attributes (which broke when the Qdrant multitenancy client stopped exposing shared_collections), import ENABLE_QDRANT_MULTITENANCY_MODE and ENABLE_MILVUS_MULTITENANCY_MODE directly from Open WebUI config. These are the authoritative source of truth that Open WebUI's own factory uses to decide which client to instantiate.

No fallback: if the config flags are not importable, the tool fails at import time with a clear error rather than silently selecting the wrong cleaner.

Fixes #8