### PR TITLE
feat: add CSV export for preview results

### DIFF
--- a/prune_cli_interactive.py
+++ b/prune_cli_interactive.py
@@ -25,7 +25,7 @@ try:
     from rich.prompt import Prompt, Confirm, IntPrompt
     from rich.table import Table
     from rich.panel import Panel
-    from rich.progress import Progress, SpinnerColumn, TextColumn
+    from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn, TimeRemainingColumn
     from rich.markdown import Markdown
     from rich import box
     from rich.tree import Tree
@@ -78,6 +78,10 @@ class InteractivePruneUI:
     def __init__(self):
         self.form_data = PruneDataForm()
         self.vector_cleaner = None
+        # Cached from last preview run — reused by export
+        self._active_file_ids = set()
+        self._active_kb_ids = set()
+        self._active_user_ids = set()
 
     def _get_all_folders_safe(self, db=None):
         """
@@ -459,18 +463,18 @@ class InteractivePruneUI:
             task = progress.add_task("Analyzing database...", total=None)
 
             try:
-                # Build sets
+                # Build sets and cache on self for export reuse
                 knowledge_bases = Knowledges.get_knowledge_bases()
                 all_users = Users.get_users()["users"]
-                active_user_ids = {user.id for user in all_users}
-                active_kb_ids = {
+                self._active_user_ids = {user.id for user in all_users}
+                self._active_kb_ids = {
                     kb.id
                     for kb in knowledge_bases
-                    if kb.user_id in active_user_ids
+                    if kb.user_id in self._active_user_ids
                 }
-                active_file_ids = get_active_file_ids(knowledge_bases, active_user_ids)
+                self._active_file_ids = get_active_file_ids(knowledge_bases, self._active_user_ids)
 
-                orphaned_counts = count_orphaned_records(self.form_data, active_file_ids, active_user_ids)
+                orphaned_counts = count_orphaned_records(self.form_data, self._active_file_ids, self._active_user_ids)
 
                 result = PrunePreviewResult(
                     inactive_users=count_inactive_users(
@@ -494,9 +498,9 @@ class InteractivePruneUI:
                     orphaned_notes=orphaned_counts["notes"],
                     orphaned_skills=orphaned_counts["skills"],
                     orphaned_folders=orphaned_counts["folders"],
-                    orphaned_uploads=count_orphaned_uploads(active_file_ids),
+                    orphaned_uploads=count_orphaned_uploads(self._active_file_ids),
                     orphaned_vector_collections=self.vector_cleaner.count_orphaned_collections(
-                        active_file_ids, active_kb_ids, active_user_ids
+                        self._active_file_ids, self._active_kb_ids, self._active_user_ids
                     ),
                     audio_cache_files=count_audio_cache_files(
                         self.form_data.audio_cache_max_age_days
@@ -514,6 +518,10 @@ class InteractivePruneUI:
         # Display results
         console.print()
         self.display_preview_results(result)
+
+        # Offer CSV export if there are items
+        if result.has_items():
+            self._offer_export(result)
 
         console.print()
         Prompt.ask("Press Enter to continue")
@@ -543,6 +551,77 @@ class InteractivePruneUI:
         console.print("\n" + "=" * 70)
         console.print(f"[bold red]TOTAL ITEMS: {result.total_items():,}[/bold red]")
         console.print("=" * 70)
+
+    def _offer_export(self, result: PrunePreviewResult):
+        """Offer to export detailed preview to CSV with double confirmation."""
+        from prune_export import PreviewExporter, format_size
+
+        exporter = PreviewExporter(
+            form_data=self.form_data,
+            vector_cleaner=self.vector_cleaner,
+            active_file_ids=self._active_file_ids,
+            active_kb_ids=self._active_kb_ids,
+            active_user_ids=self._active_user_ids,
+        )
+
+        estimated_bytes = exporter.estimate_size(result)
+        estimated_human = format_size(estimated_bytes)
+
+        # ── Confirmation 1: Do you want to export? ──
+        console.print()
+        export_choice = Prompt.ask(
+            "[bold]Export detailed item list to CSV?[/bold]",
+            choices=["yes", "no"],
+            default="no",
+        )
+
+        if export_choice == "no":
+            return
+
+        # ── Show size estimate + ask for path ──
+        console.print(f"\n  Items: [yellow]{result.total_items():,}[/yellow]")
+        console.print(f"  Estimated file size: [yellow]~{estimated_human}[/yellow]")
+
+        if estimated_bytes > 1024 * 1024 * 1024:  # > 1 GB
+            console.print(
+                "  [bold yellow]⚠ Large export — may take several minutes"
+                " and consume significant disk space[/bold yellow]"
+            )
+
+        path_input = Prompt.ask(
+            "\n  Enter file path",
+            default="prune_preview.csv",
+        )
+        output_path = Path(path_input)
+
+        # ── Confirmation 2: Confirm with size ──
+        confirm = Prompt.ask(
+            f"  Write ~{estimated_human} to {output_path}?",
+            choices=["yes", "no"],
+            default="yes",
+        )
+
+        if confirm == "no":
+            console.print("  Export cancelled.")
+            return
+
+        # ── Export with progress bar ──
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TaskProgressColumn(),
+            TimeRemainingColumn(),
+            console=console,
+        ) as progress:
+            task = progress.add_task("Exporting...", total=result.total_items())
+            rows = exporter.export(
+                output_path,
+                result,
+                progress_callback=lambda n: progress.advance(task, n),
+            )
+
+        console.print(f"\n  [green]✓[/green] Exported [bold]{rows:,}[/bold] rows to [cyan]{output_path}[/cyan]")
 
     def confirm_execution(self) -> bool:
         """Confirm execution with multiple warnings."""

--- a/prune_core.py
+++ b/prune_core.py
@@ -14,7 +14,7 @@ import shutil
 import sqlite3
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Optional, Set
+from typing import Generator, Optional, Set, Tuple
 from abc import ABC, abstractmethod
 
 # Optional database-specific imports
@@ -287,6 +287,30 @@ class VectorDatabaseCleaner(ABC):
         """
         pass
 
+    def iter_orphaned_collections(
+        self,
+        active_file_ids: Set[str],
+        active_kb_ids: Set[str],
+        active_user_ids: Optional[Set[str]] = None,
+    ) -> Generator[Tuple[str, str], None, None]:
+        """
+        Yield (orphaned_id, context) for each orphaned vector item.
+
+        Used by the export feature to list individual orphaned items.
+        Default implementation yields nothing. Subclasses override to
+        provide actual iteration.
+
+        Args:
+            active_file_ids: Set of file IDs that are still referenced
+            active_kb_ids: Set of knowledge base IDs that are still active
+            active_user_ids: Set of user IDs that are still active
+
+        Yields:
+            (orphaned_id, context_string) — e.g. ("file-abc-123", "chromadb")
+        """
+        return
+        yield  # pragma: no cover — makes this a generator
+
 
 class ChromaDatabaseCleaner(VectorDatabaseCleaner):
     """
@@ -338,6 +362,34 @@ class ChromaDatabaseCleaner(VectorDatabaseCleaner):
             log.debug(f"Error counting orphaned ChromaDB collections: {e}")
 
         return count
+
+    def iter_orphaned_collections(
+        self,
+        active_file_ids: Set[str],
+        active_kb_ids: Set[str],
+        active_user_ids: Optional[Set[str]] = None,
+    ) -> Generator[Tuple[str, str], None, None]:
+        """Yield (collection_name, context) for each orphaned ChromaDB collection."""
+        if not self.chroma_db_path.exists():
+            return
+
+        expected_collections = self._build_expected_collections(
+            active_file_ids, active_kb_ids
+        )
+        uuid_to_collection = self._get_collection_mappings()
+
+        try:
+            for collection_dir in self.vector_dir.iterdir():
+                if not collection_dir.is_dir() or collection_dir.name.startswith("."):
+                    continue
+
+                dir_uuid = collection_dir.name
+                collection_name = uuid_to_collection.get(dir_uuid)
+
+                if collection_name is None or collection_name not in expected_collections:
+                    yield (collection_name or dir_uuid, "chromadb")
+        except Exception as e:
+            log.debug(f"Error iterating orphaned ChromaDB collections: {e}")
 
     def cleanup_orphaned_collections(
         self,
@@ -724,6 +776,28 @@ class PGVectorDatabaseCleaner(VectorDatabaseCleaner):
             log.error(f"Error counting orphaned PGVector collections: {e}")
             return 0
 
+    def iter_orphaned_collections(
+        self,
+        active_file_ids: Set[str],
+        active_kb_ids: Set[str],
+        active_user_ids: Optional[Set[str]] = None,
+    ) -> Generator[Tuple[str, str], None, None]:
+        """Yield (collection_name, context) for each orphaned PGVector collection."""
+        if not self.session:
+            return
+
+        try:
+            orphaned_collections = self._get_orphaned_collections(
+                active_file_ids, active_kb_ids
+            )
+            self.session.rollback()
+            for name in orphaned_collections:
+                yield (name, "pgvector")
+        except Exception as e:
+            if self.session:
+                self.session.rollback()
+            log.debug(f"Error iterating orphaned PGVector collections: {e}")
+
     def cleanup_orphaned_collections(
         self,
         active_file_ids: Set[str],
@@ -943,6 +1017,29 @@ class MilvusDatabaseCleaner(VectorDatabaseCleaner):
             log.error(f"Error counting orphaned Milvus collections: {e}")
             return 0
 
+    def iter_orphaned_collections(
+        self,
+        active_file_ids: Set[str],
+        active_kb_ids: Set[str],
+        active_user_ids: Optional[Set[str]] = None,
+    ) -> Generator[Tuple[str, str], None, None]:
+        """Yield (original_name, full_collection_name) for each orphaned Milvus collection."""
+        try:
+            expected_collections = self._build_expected_collections(
+                active_file_ids, active_kb_ids
+            )
+            all_collections = self.vector_db_client.client.list_collections()
+
+            for collection_name in all_collections:
+                if collection_name.startswith(f"{self.collection_prefix}_"):
+                    original_name = collection_name[len(self.collection_prefix) + 1:]
+                    original_name = original_name.replace("_", "-")
+
+                    if original_name not in expected_collections:
+                        yield (original_name, collection_name)
+        except Exception as e:
+            log.debug(f"Error iterating orphaned Milvus collections: {e}")
+
     def cleanup_orphaned_collections(
         self,
         active_file_ids: Set[str],
@@ -1137,6 +1234,50 @@ class MilvusMultitenancyDatabaseCleaner(VectorDatabaseCleaner):
         except Exception as e:
             log.error(f"Error counting orphaned Milvus multitenancy collections: {e}")
             return 0
+
+    def iter_orphaned_collections(
+        self,
+        active_file_ids: Set[str],
+        active_kb_ids: Set[str],
+        active_user_ids: Optional[Set[str]] = None,
+    ) -> Generator[Tuple[str, str], None, None]:
+        """Yield (resource_id, shared_collection_name) for each orphaned Milvus MT resource."""
+        try:
+            expected_resource_ids = self._build_expected_resource_ids(
+                active_file_ids, active_kb_ids, active_user_ids
+            )
+
+            for shared_collection_name in self.shared_collections:
+                if not utility.has_collection(shared_collection_name):
+                    continue
+
+                try:
+                    collection = Collection(shared_collection_name)
+                    collection.load()
+
+                    all_resource_ids = set()
+                    iterator = collection.query_iterator(
+                        expr="",
+                        output_fields=["resource_id"],
+                        batch_size=1000,
+                    )
+
+                    while True:
+                        results = iterator.next()
+                        if not results:
+                            iterator.close()
+                            break
+                        all_resource_ids.update(res["resource_id"] for res in results)
+
+                    for resource_id in all_resource_ids:
+                        if resource_id not in expected_resource_ids:
+                            yield (resource_id, shared_collection_name)
+
+                except Exception as e:
+                    log.debug(f"Error iterating shared collection {shared_collection_name}: {e}")
+
+        except Exception as e:
+            log.debug(f"Error iterating orphaned Milvus MT collections: {e}")
 
     def cleanup_orphaned_collections(
         self,
@@ -1377,6 +1518,28 @@ class QdrantDatabaseCleaner(VectorDatabaseCleaner):
 
         return count
 
+    def iter_orphaned_collections(
+        self,
+        active_file_ids: Set[str],
+        active_kb_ids: Set[str],
+        active_user_ids: Optional[Set[str]] = None,
+    ) -> Generator[Tuple[str, str], None, None]:
+        """Yield (original_name, full_collection_name) for each orphaned Qdrant collection."""
+        try:
+            expected_collections = self._build_expected_collections(
+                active_file_ids, active_kb_ids
+            )
+            all_collections = self.client.get_collections().collections
+
+            for collection in all_collections:
+                collection_name = collection.name
+                if collection_name.startswith(f"{self.collection_prefix}_"):
+                    original_name = collection_name[len(self.collection_prefix) + 1:]
+                    if original_name not in expected_collections:
+                        yield (original_name, collection_name)
+        except Exception as e:
+            log.debug(f"Error iterating orphaned Qdrant collections: {e}")
+
     def cleanup_orphaned_collections(
         self,
         active_file_ids: Set[str],
@@ -1558,6 +1721,57 @@ class QdrantMultitenancyDatabaseCleaner(VectorDatabaseCleaner):
             return 0
 
         return orphaned_count
+
+    def iter_orphaned_collections(
+        self,
+        active_file_ids: Set[str],
+        active_kb_ids: Set[str],
+        active_user_ids: Optional[Set[str]] = None,
+    ) -> Generator[Tuple[str, str], None, None]:
+        """Yield (tenant_id, shared_collection_name) for each orphaned Qdrant MT tenant."""
+        try:
+            expected_tenant_ids = self._build_expected_tenant_ids(
+                active_file_ids, active_kb_ids, active_user_ids or set()
+            )
+
+            for collection_name in self.shared_collections:
+                if not self.client.collection_exists(collection_name=collection_name):
+                    continue
+
+                try:
+                    all_tenant_ids = set()
+                    offset = None
+
+                    while True:
+                        scroll_result = self.client.scroll(
+                            collection_name=collection_name,
+                            limit=1000,
+                            offset=offset,
+                            with_payload=True,
+                            with_vectors=False,
+                        )
+
+                        points, next_offset = scroll_result
+                        if not points:
+                            break
+
+                        for point in points:
+                            if 'tenant_id' in point.payload:
+                                all_tenant_ids.add(point.payload['tenant_id'])
+
+                        if next_offset is None:
+                            break
+                        offset = next_offset
+
+                    for tenant_id in all_tenant_ids:
+                        if tenant_id not in expected_tenant_ids:
+                            yield (tenant_id, collection_name)
+
+                except Exception as e:
+                    log.debug(f"Error iterating Qdrant collection {collection_name}: {e}")
+
+        except Exception as e:
+            log.debug(f"Error iterating orphaned Qdrant MT tenant_ids: {e}")
 
     def cleanup_orphaned_collections(
         self,

--- a/prune_export.py
+++ b/prune_export.py
@@ -1,0 +1,492 @@
+"""
+Prune Export — Detailed Preview Export to CSV
+
+This module provides streaming CSV export of all items the prune tool would
+delete. It piggybacks on the existing preview counts (no extra queries for
+counting) and iterates items category-by-category, writing each row to disk
+immediately to keep memory usage flat regardless of data size.
+
+Usage:
+    From the interactive CLI, the user is offered an export after preview.
+    From the standalone CLI, the --export-preview flag triggers the export.
+"""
+
+import csv
+import logging
+import time
+from collections import namedtuple
+from pathlib import Path
+from typing import Callable, Generator, Optional, Set
+
+from sqlalchemy import select, and_, or_, not_
+
+log = logging.getLogger(__name__)
+
+# Import Open WebUI modules using compatibility layer
+try:
+    from prune_imports import (
+        Users, Chat, Chats, File, Files, Note, Notes,
+        Prompt, Prompts, Model, Models, Knowledge, Knowledges,
+        Function, Functions, Tool, Tools, Skill, Skills,
+        Folder, Folders, ChatMessage,
+        get_db, get_db_context, CACHE_DIR,
+    )
+except ImportError as e:
+    log.error(f"Failed to import Open WebUI modules: {e}")
+    raise
+
+from prune_models import PruneDataForm, PrunePreviewResult
+from prune_core import VectorDatabaseCleaner
+from prune_operations import get_all_folders
+
+
+# Row format for the exported CSV
+ExportRow = namedtuple(
+    "ExportRow",
+    ["category", "id", "name", "owner_id", "size_bytes", "reason"],
+)
+
+# Estimated average bytes per CSV row for size estimation
+_AVG_BYTES_PER_ROW = 250
+
+
+def format_size(size_bytes: int) -> str:
+    """Format byte count as human-readable string (e.g. '12 MB', '4.2 GB')."""
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    elif size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.0f} KB"
+    elif size_bytes < 1024 * 1024 * 1024:
+        return f"{size_bytes / (1024 * 1024):.0f} MB"
+    else:
+        return f"{size_bytes / (1024 * 1024 * 1024):.1f} GB"
+
+
+class PreviewExporter:
+    """
+    Streams preview details to CSV without accumulating in memory.
+
+    All iteration happens through generator methods that yield one ExportRow
+    at a time. The CSV writer flushes each row to disk immediately via
+    Python's default 8KB file buffer.
+    """
+
+    def __init__(
+        self,
+        form_data: PruneDataForm,
+        vector_cleaner: VectorDatabaseCleaner,
+        active_file_ids: Set[str],
+        active_kb_ids: Set[str],
+        active_user_ids: Set[str],
+    ):
+        self.form_data = form_data
+        self.vector_cleaner = vector_cleaner
+        self.active_file_ids = active_file_ids
+        self.active_kb_ids = active_kb_ids
+        self.active_user_ids = active_user_ids
+
+    @staticmethod
+    def estimate_size(preview_result: PrunePreviewResult) -> int:
+        """Return estimated CSV file size in bytes from existing preview counts."""
+        return preview_result.total_items() * _AVG_BYTES_PER_ROW
+
+    def export(
+        self,
+        output_path: Path,
+        preview_result: PrunePreviewResult,
+        progress_callback: Optional[Callable[[int], None]] = None,
+    ) -> int:
+        """
+        Stream all orphaned items to a CSV file.
+
+        Args:
+            output_path: Where to write the CSV.
+            preview_result: Existing preview counts (used for context, not re-queried).
+            progress_callback: Called with 1 after each row written (for progress bar).
+
+        Returns:
+            Total rows written.
+        """
+        rows_written = 0
+
+        with open(output_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow(["category", "id", "name", "owner_id", "size_bytes", "reason"])
+
+            # Each generator yields ExportRow tuples one at a time.
+            # Only one category is iterated at a time — previous batches are GC'd.
+            generators = [
+                self._iter_inactive_users(),
+                self._iter_old_chats(),
+                self._iter_orphaned_chats(),
+                self._iter_orphaned_files(),
+                self._iter_orphaned_workspace_items(),
+                self._iter_orphaned_uploads(),
+                self._iter_orphaned_vectors(),
+                self._iter_orphaned_chat_messages(),
+                self._iter_audio_cache(),
+            ]
+
+            for gen in generators:
+                for row in gen:
+                    writer.writerow(row)
+                    rows_written += 1
+                    if progress_callback:
+                        progress_callback(1)
+
+        log.info(f"Exported {rows_written} rows to {output_path}")
+        return rows_written
+
+    # ── Per-category generators ──────────────────────────────────────────
+
+    def _iter_inactive_users(self) -> Generator[ExportRow, None, None]:
+        """Yield ExportRow for each inactive user."""
+        inactive_days = self.form_data.delete_inactive_users_days
+        if inactive_days is None:
+            return
+
+        cutoff_time = int(time.time()) - (inactive_days * 86400)
+
+        try:
+            all_users = Users.get_users()["users"]
+            for user in all_users:
+                if self.form_data.exempt_admin_users and user.role == "admin":
+                    continue
+                if self.form_data.exempt_pending_users and user.role == "pending":
+                    continue
+                if user.last_active_at < cutoff_time:
+                    yield ExportRow(
+                        category="inactive_user",
+                        id=user.id,
+                        name=user.email,
+                        owner_id="",
+                        size_bytes="",
+                        reason=f"inactive {inactive_days}+ days",
+                    )
+        except Exception as e:
+            log.debug(f"Error iterating inactive users: {e}")
+
+    def _iter_old_chats(self) -> Generator[ExportRow, None, None]:
+        """Yield ExportRow for each old chat (age-based deletion)."""
+        if self.form_data.days is None:
+            return
+
+        cutoff_time = int(time.time()) - (self.form_data.days * 86400)
+
+        try:
+            with get_db() as db:
+                conditions = [Chat.updated_at < cutoff_time]
+
+                if self.form_data.exempt_archived_chats:
+                    conditions.append(or_(Chat.archived == False, Chat.archived == None))
+
+                if self.form_data.exempt_chats_in_folders:
+                    conditions.append(and_(
+                        Chat.folder_id == None,
+                        or_(Chat.pinned == False, Chat.pinned == None)
+                    ))
+
+                stmt = select(Chat.id, Chat.title, Chat.user_id).filter(*conditions)
+
+                try:
+                    result = db.execute(stmt.execution_options(stream_results=True))
+                except AttributeError:
+                    result = db.execution_options(stream_results=True).execute(stmt)
+
+                while True:
+                    rows = result.fetchmany(1000)
+                    if not rows:
+                        break
+
+                    for chat_id, title, user_id in rows:
+                        display_title = (title or "")[:100]
+                        yield ExportRow(
+                            category="old_chat",
+                            id=chat_id,
+                            name=display_title,
+                            owner_id=user_id or "",
+                            size_bytes="",
+                            reason=f"older than {self.form_data.days} days",
+                        )
+        except Exception as e:
+            log.debug(f"Error iterating old chats: {e}")
+
+    def _iter_orphaned_chats(self) -> Generator[ExportRow, None, None]:
+        """Yield ExportRow for each orphaned chat (owner no longer exists)."""
+        if not self.form_data.delete_orphaned_chats:
+            return
+
+        if not self.active_user_ids:
+            return
+
+        try:
+            with get_db() as db:
+                stmt = select(Chat.id, Chat.title, Chat.user_id).filter(
+                    not_(Chat.user_id.in_(self.active_user_ids))
+                )
+
+                try:
+                    result = db.execute(stmt.execution_options(stream_results=True))
+                except AttributeError:
+                    result = db.execution_options(stream_results=True).execute(stmt)
+
+                while True:
+                    rows = result.fetchmany(1000)
+                    if not rows:
+                        break
+
+                    for chat_id, title, user_id in rows:
+                        display_title = (title or "")[:100]
+                        yield ExportRow(
+                            category="orphaned_chat",
+                            id=chat_id,
+                            name=display_title,
+                            owner_id=user_id or "",
+                            size_bytes="",
+                            reason="owner not in active users",
+                        )
+        except Exception as e:
+            log.debug(f"Error iterating orphaned chats: {e}")
+
+    def _iter_orphaned_files(self) -> Generator[ExportRow, None, None]:
+        """Yield ExportRow for each orphaned file record."""
+        try:
+            with get_db() as db:
+                stmt = select(File.id, File.filename, File.user_id).filter(
+                    or_(
+                        not_(File.id.in_(self.active_file_ids)) if self.active_file_ids else True,
+                        not_(File.user_id.in_(self.active_user_ids)) if self.active_user_ids else True,
+                    )
+                )
+
+                try:
+                    result = db.execute(stmt.execution_options(stream_results=True))
+                except AttributeError:
+                    result = db.execution_options(stream_results=True).execute(stmt)
+
+                while True:
+                    rows = result.fetchmany(1000)
+                    if not rows:
+                        break
+
+                    for file_id, filename, user_id in rows:
+                        reason_parts = []
+                        if file_id not in self.active_file_ids:
+                            reason_parts.append("not referenced")
+                        if user_id not in self.active_user_ids:
+                            reason_parts.append("owner not in active users")
+
+                        yield ExportRow(
+                            category="orphaned_file",
+                            id=file_id or "",
+                            name=filename or "",
+                            owner_id=user_id or "",
+                            size_bytes="",
+                            reason="; ".join(reason_parts) if reason_parts else "orphaned",
+                        )
+        except Exception as e:
+            log.debug(f"Error iterating orphaned files: {e}")
+
+    def _iter_orphaned_workspace_items(self) -> Generator[ExportRow, None, None]:
+        """Yield ExportRow for each orphaned workspace item (tools, functions, etc.)."""
+        if not self.active_user_ids:
+            return
+
+        # Map: (category_name, orm_class, id_attr, name_attr, user_id_attr, enabled_flag)
+        item_types = [
+            ("orphaned_kb", Knowledge, "id", "name", "user_id", self.form_data.delete_orphaned_knowledge_bases),
+            ("orphaned_tool", Tool, "id", "name", "user_id", self.form_data.delete_orphaned_tools),
+            ("orphaned_function", Function, "id", "name", "user_id", self.form_data.delete_orphaned_functions),
+            ("orphaned_prompt", Prompt, "command", "command", "user_id", self.form_data.delete_orphaned_prompts),
+            ("orphaned_model", Model, "id", "name", "user_id", self.form_data.delete_orphaned_models),
+            ("orphaned_note", Note, "id", "title", "user_id", self.form_data.delete_orphaned_notes),
+            ("orphaned_skill", Skill, "id", "name", "user_id", self.form_data.delete_orphaned_skills),
+        ]
+
+        for category, cls, id_attr, name_attr, uid_attr, enabled in item_types:
+            if not enabled:
+                continue
+
+            try:
+                id_col = getattr(cls, id_attr)
+                name_col = getattr(cls, name_attr)
+                uid_col = getattr(cls, uid_attr)
+
+                with get_db() as db:
+                    stmt = select(id_col, name_col, uid_col).filter(
+                        not_(uid_col.in_(self.active_user_ids))
+                    )
+
+                    try:
+                        result = db.execute(stmt.execution_options(stream_results=True))
+                    except AttributeError:
+                        result = db.execution_options(stream_results=True).execute(stmt)
+
+                    while True:
+                        rows = result.fetchmany(1000)
+                        if not rows:
+                            break
+
+                        for item_id, item_name, user_id in rows:
+                            yield ExportRow(
+                                category=category,
+                                id=str(item_id) if item_id else "",
+                                name=str(item_name or "")[:100],
+                                owner_id=user_id or "",
+                                size_bytes="",
+                                reason="owner not in active users",
+                            )
+            except Exception as e:
+                log.debug(f"Error iterating {category}: {e}")
+
+        # Orphaned folders (separate because of different API)
+        if self.form_data.delete_orphaned_folders:
+            try:
+                with get_db() as db:
+                    for folder in get_all_folders(db=db):
+                        if folder.user_id not in self.active_user_ids:
+                            yield ExportRow(
+                                category="orphaned_folder",
+                                id=str(folder.id) if folder.id else "",
+                                name=getattr(folder, "name", "") or "",
+                                owner_id=folder.user_id or "",
+                                size_bytes="",
+                                reason="owner not in active users",
+                            )
+            except Exception as e:
+                log.debug(f"Error iterating orphaned folders: {e}")
+
+    def _iter_orphaned_uploads(self) -> Generator[ExportRow, None, None]:
+        """Yield ExportRow for each orphaned physical upload file."""
+        upload_dir = Path(CACHE_DIR).parent / "uploads"
+        if not upload_dir.exists():
+            return
+
+        try:
+            for file_path in upload_dir.iterdir():
+                if not file_path.is_file():
+                    continue
+
+                filename = file_path.name
+                file_id = None
+
+                # Extract file ID from filename patterns
+                if len(filename) > 36:
+                    potential_id = filename[:36]
+                    if potential_id.count("-") == 4:
+                        file_id = potential_id
+
+                if not file_id and filename.count("-") == 4 and len(filename) == 36:
+                    file_id = filename
+
+                if not file_id:
+                    for active_id in self.active_file_ids:
+                        if active_id in filename:
+                            file_id = active_id
+                            break
+
+                if file_id and file_id not in self.active_file_ids:
+                    try:
+                        file_size = file_path.stat().st_size
+                    except OSError:
+                        file_size = ""
+
+                    yield ExportRow(
+                        category="orphaned_upload",
+                        id=file_id,
+                        name=str(file_path),
+                        owner_id="",
+                        size_bytes=file_size,
+                        reason="no matching DB record",
+                    )
+        except Exception as e:
+            log.debug(f"Error iterating orphaned uploads: {e}")
+
+    def _iter_orphaned_vectors(self) -> Generator[ExportRow, None, None]:
+        """Yield ExportRow for each orphaned vector collection/tenant."""
+        try:
+            for orphaned_id, context in self.vector_cleaner.iter_orphaned_collections(
+                self.active_file_ids, self.active_kb_ids, self.active_user_ids
+            ):
+                yield ExportRow(
+                    category="orphaned_vector",
+                    id=orphaned_id or "",
+                    name=context or "",
+                    owner_id="",
+                    size_bytes="",
+                    reason="no matching active file or knowledge base",
+                )
+        except Exception as e:
+            log.debug(f"Error iterating orphaned vectors: {e}")
+
+    def _iter_orphaned_chat_messages(self) -> Generator[ExportRow, None, None]:
+        """Yield ExportRow for each orphaned chat message."""
+        if not self.form_data.delete_orphaned_chat_messages:
+            return
+
+        try:
+            with get_db() as db:
+                stmt = select(ChatMessage.id, ChatMessage.chat_id).filter(
+                    not_(ChatMessage.chat_id.in_(select(Chat.id)))
+                )
+
+                try:
+                    result = db.execute(stmt.execution_options(stream_results=True))
+                except AttributeError:
+                    result = db.execution_options(stream_results=True).execute(stmt)
+
+                while True:
+                    rows = result.fetchmany(1000)
+                    if not rows:
+                        break
+
+                    for message_id, chat_id in rows:
+                        yield ExportRow(
+                            category="orphaned_chat_message",
+                            id=message_id or "",
+                            name=f"chat: {chat_id}" if chat_id else "",
+                            owner_id="",
+                            size_bytes="",
+                            reason="parent chat no longer exists",
+                        )
+        except Exception as e:
+            log.debug(f"Error iterating orphaned chat messages (table may not exist): {e}")
+
+    def _iter_audio_cache(self) -> Generator[ExportRow, None, None]:
+        """Yield ExportRow for each old audio cache file."""
+        max_age_days = self.form_data.audio_cache_max_age_days
+        if max_age_days is None:
+            return
+
+        cutoff_time = time.time() - (max_age_days * 86400)
+
+        audio_dirs = [
+            Path(CACHE_DIR) / "audio" / "speech",
+            Path(CACHE_DIR) / "audio" / "transcriptions",
+        ]
+
+        for audio_dir in audio_dirs:
+            if not audio_dir.exists():
+                continue
+
+            try:
+                for file_path in audio_dir.iterdir():
+                    if not file_path.is_file():
+                        continue
+
+                    try:
+                        stat = file_path.stat()
+                    except OSError:
+                        continue
+
+                    if stat.st_mtime < cutoff_time:
+                        yield ExportRow(
+                            category="audio_cache",
+                            id="",
+                            name=str(file_path),
+                            owner_id="",
+                            size_bytes=stat.st_size,
+                            reason=f"older than {max_age_days} days",
+                        )
+            except Exception as e:
+                log.debug(f"Error iterating audio cache in {audio_dir}: {e}")

--- a/standalone_prune.py
+++ b/standalone_prune.py
@@ -293,6 +293,15 @@ Safety Features:
         help='Suppress all output except errors'
     )
 
+    # Export
+    parser.add_argument(
+        '--export-preview',
+        type=str,
+        default=None,
+        metavar='PATH',
+        help='Export detailed preview to CSV file (requires --dry-run)'
+    )
+
     args = parser.parse_args()
 
     # If neither --dry-run nor --execute specified, default to dry-run
@@ -303,6 +312,10 @@ Safety Features:
     # Can't have both dry-run and execute
     if args.dry_run and args.execute:
         parser.error("Cannot specify both --dry-run and --execute")
+
+    # --export-preview requires --dry-run
+    if args.export_preview and not args.dry_run:
+        parser.error("--export-preview requires --dry-run mode")
 
     return args
 
@@ -422,7 +435,7 @@ def print_preview_results(result: PrunePreviewResult):
     print()
 
 
-def run_prune(form_data: PruneDataForm):
+def run_prune(form_data: PruneDataForm, export_preview_path: str = None):
     """
     Execute the prune operation with the given configuration.
     This replicates the logic from prune.py's prune_data function.
@@ -486,6 +499,27 @@ def run_prune(form_data: PruneDataForm):
 
             log.info("Data pruning preview completed")
             print_preview_results(result)
+
+            # Export detailed preview to CSV if requested
+            if export_preview_path and result.has_items():
+                from prune_export import PreviewExporter, format_size
+
+                exporter = PreviewExporter(
+                    form_data=form_data,
+                    vector_cleaner=vector_cleaner,
+                    active_file_ids=active_file_ids,
+                    active_kb_ids=active_kb_ids,
+                    active_user_ids=active_user_ids,
+                )
+
+                estimated_human = format_size(exporter.estimate_size(result))
+                log.info(
+                    f"Exporting {result.total_items()} items (~{estimated_human}) "
+                    f"to {export_preview_path}"
+                )
+                rows = exporter.export(Path(export_preview_path), result)
+                log.info(f"Exported {rows} rows to {export_preview_path}")
+
             return True
 
         # Actual deletion logic (dry_run=False)
@@ -869,7 +903,7 @@ def main():
     log.info("")
 
     # Run the prune operation
-    success = run_prune(form_data)
+    success = run_prune(form_data, export_preview_path=args.export_preview)
 
     if success:
         log.info("\n✓ Prune operation completed successfully")


### PR DESCRIPTION
Add a new --export-preview flag (standalone) and interactive export offer (CLI) that streams all items the prune tool would delete to a CSV file.

New file: prune_export.py
- PreviewExporter class with per-category generator methods
- ExportRow namedtuple: category, id, name, owner_id, size_bytes, reason
- size_bytes populated for filesystem items (uploads, audio cache)
- format_size helper for human-readable byte counts
- estimate_size for pre-export size estimation

Modified: prune_core.py
- Add iter_orphaned_collections() to VectorDatabaseCleaner base class
- Override in all 7 subclasses (Chroma, PGVector, Qdrant, Qdrant MT, Milvus, Milvus MT, NoOp)

Modified: prune_cli_interactive.py
- Cache active sets on self for export reuse
- Add _offer_export() with double confirmation flow
- Rich progress bar with ETA during export

Modified: standalone_prune.py
- Add --export-preview PATH flag (requires --dry-run)
- Export runs after preview results are printed

