### PR TITLE
feat: add separate pinned chat exemption flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ python prune/prune.py --days 60 --dry-run
 python prune/prune.py \
   --days 180 \
   --exempt-archived-chats \
+  --exempt-pinned-chats \
   --exempt-chats-in-folders \
   --execute
 ```
@@ -367,7 +368,8 @@ python prune/prune.py \
 |--------|------|---------|-------------|-------------|
 | `--days N` | int | None | — | Delete chats older than N days |
 | `--exempt-archived-chats` | flag | False | — | Keep archived chats |
-| `--exempt-chats-in-folders` | flag | False | — | Keep chats in folders/pinned |
+| `--exempt-pinned-chats` | flag | False | — | Keep pinned chats |
+| `--exempt-chats-in-folders` | flag | False | — | Keep chats in folders |
 | `--delete-inactive-users-days N` | int | None | — | Delete users inactive N+ days |
 | `--exempt-admin-users` | flag | True | `--no-exempt-admin-users` | Never delete admins (RECOMMENDED) |
 | `--exempt-pending-users` | flag | True | `--no-exempt-pending-users` | Never delete pending users |
@@ -647,7 +649,7 @@ If operations are very slow:
 - Referenced files
 - Valid vector collections
 - Recent data (within retention period)
-- Exempted categories (archived, folders, admins)
+- Exempted categories (archived, pinned, folders, admins)
 
 ### Vector Database Support
 

--- a/prune.py
+++ b/prune.py
@@ -114,7 +114,8 @@ Common Options:
 Age-Based Deletion:
   --days N                     Delete chats older than N days
   --exempt-archived-chats      Keep archived chats even if old
-  --exempt-chats-in-folders    Keep organized chats
+  --exempt-pinned-chats        Keep pinned chats even if old
+  --exempt-chats-in-folders    Keep chats in folders
 
 User Deletion:
   --delete-inactive-users-days N    Delete users inactive for N+ days

--- a/prune_cli_interactive.py
+++ b/prune_cli_interactive.py
@@ -290,8 +290,12 @@ class InteractivePruneUI:
                 "Keep archived chats even if old?",
                 default=True
             )
+            self.form_data.exempt_pinned_chats = Confirm.ask(
+                "Keep pinned chats even if old?",
+                default=False
+            )
             self.form_data.exempt_chats_in_folders = Confirm.ask(
-                "Keep chats in folders/pinned even if old?",
+                "Keep chats in folders even if old?",
                 default=False
             )
 
@@ -417,6 +421,7 @@ class InteractivePruneUI:
         if self.form_data.days is not None:
             console.print(f"  [yellow]Enabled[/yellow] - Delete chats older than {self.form_data.days} days")
             console.print(f"    Exempt archived: {'Yes' if self.form_data.exempt_archived_chats else 'No'}")
+            console.print(f"    Exempt pinned: {'Yes' if self.form_data.exempt_pinned_chats else 'No'}")
             console.print(f"    Exempt in folders: {'Yes' if self.form_data.exempt_chats_in_folders else 'No'}")
         else:
             console.print("  [dim]Disabled[/dim]")
@@ -501,6 +506,7 @@ class InteractivePruneUI:
                         self.form_data.days,
                         self.form_data.exempt_archived_chats,
                         self.form_data.exempt_chats_in_folders,
+                        self.form_data.exempt_pinned_chats,
                     ),
                     orphaned_chats=orphaned_counts["chats"],
                     orphaned_files=orphaned_counts["files"],
@@ -706,11 +712,11 @@ class InteractivePruneUI:
                     conditions = Chat.updated_at < cutoff_time
                     if self.form_data.exempt_archived_chats:
                         conditions &= or_(Chat.archived == False, Chat.archived == None)
+                    if self.form_data.exempt_pinned_chats and hasattr(Chat, 'pinned'):
+                        conditions &= or_(Chat.pinned == False, Chat.pinned == None)
                     if self.form_data.exempt_chats_in_folders:
                         if hasattr(Chat, 'folder_id'):
                             conditions &= Chat.folder_id == None
-                        if hasattr(Chat, 'pinned'):
-                            conditions &= or_(Chat.pinned == False, Chat.pinned == None)
 
                     async for (chat_id,) in stream_rows(db, Chat.id, filter_clause=conditions):
                         await Chats.delete_chat_by_id(chat_id, db=db)

--- a/prune_export.py
+++ b/prune_export.py
@@ -183,12 +183,13 @@ class PreviewExporter:
                 if self.form_data.exempt_archived_chats:
                     conditions.append(or_(Chat.archived == False, Chat.archived == None))
 
+                if self.form_data.exempt_pinned_chats and hasattr(Chat, 'pinned'):
+                    conditions.append(or_(Chat.pinned == False, Chat.pinned == None))
+
                 if self.form_data.exempt_chats_in_folders:
                     folder_conditions = []
                     if hasattr(Chat, 'folder_id'):
                         folder_conditions.append(Chat.folder_id == None)
-                    if hasattr(Chat, 'pinned'):
-                        folder_conditions.append(or_(Chat.pinned == False, Chat.pinned == None))
                     if folder_conditions:
                         conditions.append(and_(*folder_conditions))
 

--- a/prune_models.py
+++ b/prune_models.py
@@ -20,6 +20,7 @@ class PruneDataForm(BaseModel):
     """
     days: Optional[int] = None
     exempt_archived_chats: bool = False
+    exempt_pinned_chats: bool = False
     exempt_chats_in_folders: bool = False
     delete_orphaned_chats: bool = True
     delete_orphaned_tools: bool = False

--- a/prune_operations.py
+++ b/prune_operations.py
@@ -225,7 +225,10 @@ async def count_inactive_users(
 
 
 async def count_old_chats(
-    days: Optional[int], exempt_archived: bool, exempt_in_folders: bool
+    days: Optional[int],
+    exempt_archived: bool,
+    exempt_in_folders: bool,
+    exempt_pinned: bool,
 ) -> int:
     """Count chats that would be deleted by age.
 
@@ -245,12 +248,13 @@ async def count_old_chats(
             if exempt_archived:
                 conditions.append(or_(Chat.archived == False, Chat.archived == None))
 
+            if exempt_pinned and hasattr(Chat, 'pinned'):
+                conditions.append(or_(Chat.pinned == False, Chat.pinned == None))
+
             if exempt_in_folders:
                 folder_conditions = []
                 if hasattr(Chat, 'folder_id'):
                     folder_conditions.append(Chat.folder_id == None)
-                if hasattr(Chat, 'pinned'):
-                    folder_conditions.append(or_(Chat.pinned == False, Chat.pinned == None))
                 if folder_conditions:
                     conditions.append(and_(*folder_conditions))
 

--- a/standalone_prune.py
+++ b/standalone_prune.py
@@ -119,7 +119,7 @@ Safety Features:
   - Uses file-based locking to prevent concurrent runs
   - Dry-run mode enabled by default (use --execute to actually delete)
   - Detailed logging of all operations
-  - Preserves archived chats and folder-organized chats by default
+  - Supports exemptions for archived, pinned, and folder-organized chats
   - Admin users exempted from deletion by default
         """
     )
@@ -159,10 +159,16 @@ Safety Features:
         help='Include archived chats in age-based deletion'
     )
     parser.add_argument(
+        '--exempt-pinned-chats',
+        action='store_true',
+        default=False,
+        help='Keep pinned chats even if old'
+    )
+    parser.add_argument(
         '--exempt-chats-in-folders',
         action='store_true',
         default=False,
-        help='Keep chats in folders/pinned even if old'
+        help='Keep chats in folders even if old'
     )
 
     # Inactive user deletion
@@ -389,6 +395,7 @@ def create_prune_form(args) -> PruneDataForm:
     return PruneDataForm(
         days=args.days,
         exempt_archived_chats=args.exempt_archived_chats,
+        exempt_pinned_chats=args.exempt_pinned_chats,
         exempt_chats_in_folders=args.exempt_chats_in_folders,
         delete_orphaned_chats=args.delete_orphaned_chats,
         delete_orphaned_tools=args.delete_orphaned_tools,
@@ -544,6 +551,7 @@ async def run_prune(form_data: PruneDataForm, export_preview_path: str = None):
                     form_data.days,
                     form_data.exempt_archived_chats,
                     form_data.exempt_chats_in_folders,
+                    form_data.exempt_pinned_chats,
                 ),
                 orphaned_chats=orphaned_counts["chats"],
                 orphaned_files=orphaned_counts["files"],
@@ -622,11 +630,11 @@ async def run_prune(form_data: PruneDataForm, export_preview_path: str = None):
                 conditions = Chat.updated_at < cutoff_time
                 if form_data.exempt_archived_chats:
                     conditions &= or_(Chat.archived == False, Chat.archived == None)
+                if form_data.exempt_pinned_chats and hasattr(Chat, 'pinned'):
+                    conditions &= or_(Chat.pinned == False, Chat.pinned == None)
                 if form_data.exempt_chats_in_folders:
                     if hasattr(Chat, 'folder_id'):
                         conditions &= Chat.folder_id == None
-                    if hasattr(Chat, 'pinned'):
-                        conditions &= or_(Chat.pinned == False, Chat.pinned == None)
 
                 deleted = 0
                 async for (chat_id,) in stream_rows(db, Chat.id, filter_clause=conditions):
@@ -947,6 +955,7 @@ async def async_main():
     if form_data.days is not None:
         log.info(f"  Delete chats older than: {form_data.days} days")
         log.info(f"    Exempt archived chats: {form_data.exempt_archived_chats}")
+        log.info(f"    Exempt pinned chats: {form_data.exempt_pinned_chats}")
         log.info(f"    Exempt chats in folders: {form_data.exempt_chats_in_folders}")
 
     if form_data.delete_inactive_users_days is not None:


### PR DESCRIPTION
## Target Branch: `main` (`dev` doesn't exist)

## PR Title Format

feat: add separate pinned chat exemption flag

## Scope Check (REQUIRED)

- [x] This PR addresses **exactly one** concern (one bug, one feature, one refactor)
- [x] This PR does NOT bundle unrelated changes (no "while I was here" fixes)
- [x] Every changed file is directly related to the stated purpose
- [x] If this PR touches more than 3 files, I have justified why below

**Scope justification (if >3 files changed):**

This adds a new prune option that must be represented consistently across the shared config model, standalone CLI, interactive CLI, preview counting, preview export, deletion filtering, and user-facing documentation.

## Description (REQUIRED)

Adds a separate `--exempt-pinned-chats` flag for age-based chat pruning.

Previously, pinned chats were *implicitly* protected as part of `--exempt-chats-in-folders`. This change makes pinned chat preservation explicit via a designated flag, while `--exempt-chats-in-folders` now only protects chats assigned to folders.

## Why

Pinned and foldered chats are separate Open WebUI organization concepts. Users may want to preserve one category without preserving the other during age-based cleanup.

---

## Testing — General (REQUIRED)

### Database Testing

- [ ] Tested with **SQLite** database
- [ ] Tested with **PostgreSQL** database
- [ ] If only one DB tested, explain why:

### Functional Testing

- [ ] Tested **preview mode** (dry run)
- [ ] Verified preview counts are accurate
- [ ] Tested **full execution** (actual deletions performed)
- [ ] Verified deleted records are actually removed from DB
- [ ] Tested with **no orphaned data** (script handles clean state gracefully)
- [ ] Tested with **large dataset** if performance-related change

## Testing — Vector Database (IF APPLICABLE)

- [x] N/A — This PR does not touch vector DB logic
- [ ] Tested orphaned collection detection
- [ ] Tested orphaned collection deletion
- [ ] Tested internal metadata / record cleanup (if applicable)
- [ ] Verified active collections are NOT deleted

---

## Checklist

- [x] I have read and followed the scope requirements above
- [ ] I have tested my changes as documented above

---

## Contributor License Agreement (REQUIRED)

By submitting this pull request, I agree to the following terms:

By submitting my contributions to this repository in any form, I grant Open WebUI Inc. a perpetual, worldwide, irrevocable, royalty-free license, under copyright and patent, to use, modify, distribute, sublicense, and commercialize my work under any terms they choose, both now and in the future.

I represent that my contributions are my original work (or that I have sufficient rights to grant this license) and that I have the authority to enter into this agreement.

**_To the fullest extent permitted by law, my contributions are provided on an "as is" basis, with no warranties or guarantees of any kind, and I disclaim any liability for any issues or damages arising from their use or incorporation into the project, regardless of the type of legal claim._**

- [x] I have read and agree to the Contributor License Agreement above