### PR TITLE
fix: gate vector database vacuum behind run-vacuum

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ When you delete a user, **ALL their data is deleted**:
 ### ⚠️ VACUUM Locks Database
 
 When `--run-vacuum` is enabled:
-- **Entire database is locked** during operation
+- **Main and vector databases may be locked** during operation
 - **All users will experience errors**
 - Can take **5-30+ minutes** (or longer)
 - **Only use during scheduled maintenance windows**

--- a/prune_cli_interactive.py
+++ b/prune_cli_interactive.py
@@ -375,7 +375,7 @@ class InteractivePruneUI:
         """Configure VACUUM optimization."""
         console.print("\n[bold red]⚠ DATABASE VACUUM WARNING[/bold red]")
         console.print()
-        console.print("VACUUM reclaims disk space by rebuilding the database file.")
+        console.print("VACUUM reclaims disk space in the main and vector databases.")
         console.print()
         console.print("[bold yellow]⚠ Critical Warnings:[/bold yellow]")
         console.print("  • LOCKS the entire database during execution")

--- a/prune_core.py
+++ b/prune_core.py
@@ -901,24 +901,6 @@ class PGVectorDatabaseCleaner(VectorDatabaseCleaner):
                 if self.session:
                     self.session.rollback()
 
-            # PostgreSQL-specific optimization (if we have access to session)
-            # VACUUM must run in autocommit mode (outside transaction)
-            try:
-                if self.session:
-                    engine = self.session.get_bind()
-                    raw_connection = engine.raw_connection()
-                    try:
-                        raw_connection.set_isolation_level(0)  # AUTOCOMMIT mode
-                        cursor = raw_connection.cursor()
-                        cursor.execute("VACUUM ANALYZE document_chunk")
-                        cursor.close()
-                        raw_connection.commit()
-                        log.debug("Executed VACUUM ANALYZE on document_chunk table")
-                    finally:
-                        raw_connection.close()
-            except Exception as e:
-                log.warning(f"Failed to VACUUM PGVector table: {e}")
-
             total_deleted = deleted_count + orphaned_chunks_deleted
             if total_deleted > 0:
                 log.info(
@@ -2082,5 +2064,4 @@ def get_vector_database_cleaner(
             f"No specific cleaner for vector database type: {vector_db_type}, using no-op cleaner"
         )
         return NoOpVectorDatabaseCleaner()
-
 

--- a/standalone_prune.py
+++ b/standalone_prune.py
@@ -328,7 +328,9 @@ Safety Features:
         '--run-vacuum',
         action='store_true',
         default=False,
-        help='Run VACUUM to reclaim disk space (LOCKS DATABASE, use during maintenance)'
+        help=(
+            'Run VACUUM on main and vector databases to reclaim disk space (LOCKS DATABASE, use during maintenance)'
+        )
     )
 
     # Logging


### PR DESCRIPTION
## Target Branch: `main`

## Scope Check (REQUIRED)

- [x] This PR addresses **exactly one** concern (one bug, one feature, one refactor)
- [x] This PR does NOT bundle unrelated changes (no "while I was here" fixes)
- [x] Every changed file is directly related to the stated purpose
- [x] If this PR touches more than 3 files, I have justified why below

**Scope justification (if >3 files changed):**

The behavior fix is in the PGVector cleanup implementation, while the other changed files update CLI/help/README text so `--run-vacuum` accurately describes main and vector database optimization.

## Description (REQUIRED)

Stops PGVector cleanup from running `VACUUM ANALYZE document_chunk` unconditionally during vector cleanup.

Vector database vacuuming is now handled only by the existing `--run-vacuum` maintenance stage, which already covers ChromaDB and PGVector when enabled.

## Why

`--run-vacuum` is documented as an explicit maintenance-window operation, but PGVector cleanup could still run VACUUM even when that flag was not set. This makes the flag accurately control vector database vacuuming.

---

## Testing — General (REQUIRED)

### Database Testing

- [ ] Tested with **SQLite** database
- [ ] Tested with **PostgreSQL** database
- [ ] If only one DB tested, explain why: 

### Functional Testing

- [ ] Tested **preview mode** (dry run)
- [ ] Verified preview counts are accurate
- [ ] Tested **full execution** (actual deletions performed)
- [ ] Verified deleted records are actually removed from DB
- [ ] Tested with **no orphaned data** (script handles clean state gracefully)
- [ ] Tested with **large dataset** if performance-related change

## Testing — Vector Database (IF APPLICABLE)

- [ ] N/A — This PR does not touch vector DB logic
- [ ] Tested orphaned collection detection
- [ ] Tested orphaned collection deletion
- [ ] Tested internal metadata / record cleanup (if applicable)
- [ ] Verified active collections are NOT deleted

---

## Checklist

- [x] I have read and followed the scope requirements above
- [ ] I have tested my changes as documented above

---

## Contributor License Agreement (REQUIRED)


By submitting this pull request, I agree to the following terms:

By submitting my contributions to this repository in any form, I grant Open WebUI Inc. a perpetual, worldwide, irrevocable, royalty-free license, under copyright and patent, to use, modify, distribute, sublicense, and commercialize my work under any terms they choose, both now and in the future.

I represent that my contributions are my original work (or that I have sufficient rights to grant this license) and that I have the authority to enter into this agreement.

**_To the fullest extent permitted by law, my contributions are provided on an "as is" basis, with no warranties or guarantees of any kind, and I disclaim any liability for any issues or damages arising from their use or incorporation into the project, regardless of the type of legal claim._**

- [x] I have read and agree to the Contributor License Agreement above